### PR TITLE
fix: disable @typescript-eslint/no-unused-vars rule

### DIFF
--- a/typescript.js
+++ b/typescript.js
@@ -10,7 +10,7 @@ module.exports = {
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/no-non-null-assertion': 'warn',
     '@typescript-eslint/no-shadow': 'warn',
-    '@typescript-eslint/no-unused-vars': ['warn', { ignoreRestSiblings: true }],
+    '@typescript-eslint/no-unused-vars': 'off',
     'no-shadow': 'off',
   },
 };


### PR DESCRIPTION
TypeScript can be configured to handle it instead