### PR TITLE
ci: drop `--provenance` flag as it's the default

### DIFF
--- a/.github/workflows/publish-package.yaml
+++ b/.github/workflows/publish-package.yaml
@@ -19,4 +19,4 @@ jobs:
           cache: pnpm
           registry-url: https://registry.npmjs.org/
       - run: pnpm install --frozen-lockfile
-      - run: pnpm publish --access public --no-git-checks --provenance
+      - run: pnpm publish --access public --no-git-checks


### PR DESCRIPTION
See https://docs.npmjs.com/trusted-publishers#automatic-provenance-generation